### PR TITLE
Add Dockerfile and docker-compose.yml for containerized deployment

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,2 @@
+PLEX_URL=http://your-plex-server-ip:32400
+PLEX_TOKEN=your_plex_token_here

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+            type=semver,pattern={{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir plex-mcp-server
+
+EXPOSE 3001
+
+ENTRYPOINT ["plex-mcp-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,5 @@ services:
     restart: unless-stopped
     ports:
       - "3001:3001"
-    environment:
-      - PLEX_URL=${PLEX_URL}
-      - PLEX_TOKEN=${PLEX_TOKEN}
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  plex-mcp-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: plex-mcp-server
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    environment:
+      - PLEX_URL=${PLEX_URL}
+      - PLEX_TOKEN=${PLEX_TOKEN}


### PR DESCRIPTION
## Summary

This project currently has no Docker deployment path (install is via `pip`/`uvx` only). Adds a minimal, self-contained Docker setup so it can be run as a long-lived container (e.g. on a home server / NAS alongside other self-hosted services), which is a common way people run MCP servers that need to stay up continuously for SSE-based remote access.

- `Dockerfile` — `python:3.12-slim` base, installs the published `plex-mcp-server` PyPI package directly (no source build needed), runs it via its console-script entrypoint.
- `docker-compose.yml` — runs the server with the default `sse` transport on port 3001, reading `PLEX_URL`/`PLEX_TOKEN` from a `.env` file via `env_file`.
- `.env.docker.example` — template for the two required variables.

## Test plan

- [x] Built and ran the image locally against a real Plex server (Synology-hosted)
- [x] Verified the `/sse` endpoint announces the message endpoint correctly
- [x] Performed a full MCP handshake (`initialize` → `notifications/initialized`) over the SSE transport
- [x] Called `tools/list` and confirmed all ~55 tools are registered
- [x] Called `library_list` and confirmed it returns real library data from the connected Plex server